### PR TITLE
Update to Svelte v4 and SvelteKit v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.28.1",
-        "@sveltejs/adapter-auto": "^2.0.0",
+        "@sveltejs/adapter-auto": "^3.0.0",
         "@sveltejs/adapter-static": "^2.0.1",
-        "@sveltejs/kit": "^1.5.0",
+        "@sveltejs/kit": "^2.0.0",
         "@sveltejs/package": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -22,7 +22,7 @@
         "prettier": "^2.8.0",
         "prettier-plugin-svelte": "^2.8.1",
         "publint": "^0.1.9",
-        "svelte": "^3.54.0",
+        "svelte": "^4.2.12",
         "svelte-check": "^3.0.1",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
@@ -40,7 +40,7 @@
     ],
     "name": "svelte-image-input",
     "peerDependencies": {
-        "svelte": "^3.54.0"
+        "svelte": "^4.2.12"
     },
     "scripts": {
         "build": "vite build && npm run package",


### PR DESCRIPTION
Simple package.json update as it already functions correctly in the latest version of Svelte and SvelteKit

This should be done to keep compatibility as this is still a great and very useful library. 